### PR TITLE
Docs: Heavy-cycle quality pass — architecture, references, user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,13 +289,17 @@ Udec_Robotic_Writer/
 
 | Document | Description |
 |----------|-------------|
-| [Kinematics Equations](docs/equations/kinematics.md) | Complete mathematical derivation of FK/IK |
+| [User Guide](docs/user_guide.md) | Install, GUI tour, API curl example, hardware backends, troubleshooting |
+| [Architecture](docs/architecture.md) | Layered view, request lifecycle, module responsibilities, extension points |
 | [Methodology](docs/methodology.md) | Problem statement, approach, and system design |
+| [Kinematics Equations](docs/equations/kinematics.md) | Complete mathematical derivation of FK/IK |
 | [Arduino Firmware](docs/arduino_firmware.md) | Protocol specification and example Arduino sketch |
+| [Development History](docs/development_history.md) | Reverse-chronological change log |
+| [References](docs/references.md) | External bibliography (Craig, Spong, LaValle, ...) |
 | [DH Frames Diagram](docs/diagrams/dh_frames.svg) | Denavit-Hartenberg reference frames |
 | [Setup Diagram](docs/diagrams/robot_setup.svg) | Physical workspace layout |
 | [Flowchart](docs/diagrams/solution_flowchart.svg) | Solution algorithm flow |
-| [Architecture](docs/diagrams/system_architecture.svg) | System component diagram |
+| [Architecture SVG](docs/diagrams/system_architecture.svg) | System component diagram |
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,97 @@
+# Architecture — Robotic Writer
+
+System-level overview of how the Robotic Writer components fit together. For the full problem formulation, see [methodology.md](methodology.md); for derivations, see [equations/kinematics.md](equations/kinematics.md).
+
+## 1. Layered View
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Frontend (Dash + Plotly)         src/frontend/app.py   │
+│  • Kinematics tab • Animation tab • Writer tab          │
+└───────────────▲─────────────────────────────────────────┘
+                │  HTTP / JSON
+┌───────────────┴─────────────────────────────────────────┐
+│  REST API (FastAPI)               src/api/main.py       │
+│  /api/kinematics/{forward,inverse}  /api/writer/simulate│
+│  /api/robot/state  /api/hardware/*  /api/health         │
+└───────────────▲─────────────────────────────────────────┘
+                │  Python calls
+┌───────────────┴─────────────────────────────────────────┐
+│  Core engine                      src/core/             │
+│  • kinematics.py  — DH, FK, IK, joint limits            │
+│  • robot.py       — ScorbotIII model + trajectory plan  │
+│  • writer.py      — block circle / writing line / cycle │
+│  • rrt_planner.py — collision-free motion planning      │
+│  • cursive.py     — Bezier cursive character paths      │
+└───────────────▲─────────────────────────────────────────┘
+                │  optional, only when driving real HW
+┌───────────────┴─────────────────────────────────────────┐
+│  Hardware adapters                src/hardware/         │
+│  base.py (interface) + matlab_adapter / arduino /       │
+│  serial_adapter                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+An SVG equivalent lives at [diagrams/system_architecture.svg](diagrams/system_architecture.svg).
+
+## 2. Request Lifecycle — `POST /api/writer/simulate`
+
+1. Frontend posts the text string and geometry parameters.
+2. API validates the payload through Pydantic (`WriteRequest`).
+3. API constructs `BlockCircle`, `WritingLine`, and `RoboticWriter`.
+4. Writer runs the pick-and-place loop per character, delegating:
+   - IK computation → `core.kinematics.InverseKinematics`
+   - Joint-space trajectories → `core.robot.ScorbotIII.plan_trajectory`
+   - Optional obstacle avoidance → `core.rrt_planner.RRTPlanner`
+5. API returns a trajectory record (joint angles, EE positions, timestamps).
+6. Frontend renders the animation from that record — **no** server round-trip per frame (this was the v2.6 fix).
+
+## 3. Core Modules
+
+| Module | Responsibility | Notes |
+|---|---|---|
+| `kinematics.py` | DH parameters, `ForwardKinematics`, `InverseKinematics`, `JointState`, `JOINT_LIMITS_DEG` | Closed-form analytic IK, elbow-up/down resolved by collision avoidance |
+| `robot.py` | `ScorbotIII` robot facade | Wraps FK/IK + trajectory planning + joint-limit validation |
+| `writer.py` | Writing pipeline | `BlockCircle`, `WritingLine`, `RoboticWriter` orchestrator |
+| `rrt_planner.py` | Sampling-based planner | 1000-iteration limit + post-smoothing, used for non-trivial obstacles |
+| `cursive.py` | Bezier curve generator | Per-character control points for cursive writing mode |
+| `modes.py` | Text mode heuristics | Block vs cursive selection hints |
+
+## 4. API Surface (stable v1)
+
+| Method | Endpoint | Purpose |
+|---|---|---|
+| POST | `/api/writer/simulate` | Full pick-and-place trajectory for a string |
+| POST | `/api/kinematics/forward` | FK from 5 joint angles |
+| POST | `/api/kinematics/inverse` | IK from target (x, y, z, approach) |
+| GET  | `/api/robot/state` | Current joint / gripper state |
+| POST | `/api/hardware/connect` | Attach a hardware adapter |
+| GET  | `/api/health` | Liveness probe |
+
+Validation ranges (`block_radius_mm 200–400`, `writing_angular_spacing_deg 2–8`, etc.) live in Pydantic models in `src/api/main.py` — per the `API Defaults` rule, any frontend default should be checked against these bounds.
+
+## 5. Hardware Adapter Contract
+
+All adapters implement `HardwareAdapter` (`src/hardware/base.py`) with:
+
+- `connect(**kwargs)` / `disconnect()`
+- `send_command(cmd: str) -> str`
+- `move_motor(joint_id: int, steps: int)`
+- `emergency_stop()`
+
+This lets the same `ScorbotIII` engine drive simulation **or** real hardware by swapping one dependency.
+
+## 6. Extension Points
+
+- **New letter glyphs** → add to `core/cursive.py` (Bezier control points).
+- **New planner** → implement the same `plan(start, goal, obstacles)` signature as `RRTPlanner`.
+- **New hardware** → subclass `HardwareAdapter`, register in `src/hardware/__init__.py`.
+- **New API endpoint** → add route + Pydantic schema in `src/api/main.py`, cover with `tests/test_api.py`.
+
+## 7. Test Strategy
+
+- `test_kinematics.py` — FK/IK round-trips and joint-limit edge cases.
+- `test_robot.py` — full `ScorbotIII` trajectory continuity (C¹).
+- `test_rrt_planner.py` — path feasibility and smoothing invariants.
+- `test_cursive.py` — character path topology.
+- `test_api.py` — endpoint contracts via FastAPI TestClient.

--- a/docs/development_history.md
+++ b/docs/development_history.md
@@ -1,6 +1,20 @@
-# Methodology History
+# Development History
 
 Reverse-chronological log of design decisions, changes, equations, and improvements applied to the Robotic Writer project. Most recent changes appear first.
+
+> Previously titled *Methodology History* — renamed to match the repo-wide convention (`docs/development_history.md`).
+
+---
+
+## v2.8 — Docs Quality Pass (2026-04-18)
+
+Heavy-cycle docs audit. Added:
+
+- [architecture.md](architecture.md) — layered view, request lifecycle for `POST /api/writer/simulate`, module responsibilities, extension points, test strategy.
+- [references.md](references.md) — curated bibliography (Craig, Spong, LaValle, Scorbot manual, FastAPI/Dash, de Casteljau).
+- [user_guide.md](user_guide.md) — install, GUI tour, API curl example, hardware backends, troubleshooting table.
+
+Also renamed `docs/Methodology_history.md` → `docs/development_history.md` to match the project-quality-standards naming convention. Private-data sweep: clean (all grep hits were benign localhost / COM-port examples; the string `"A SECRET"` in `src/core/modes.py` is a test phrase, not a credential). Deployment note moved/created at `CAOS_MANAGE/deployments/robotic-writer.md`.
 
 ---
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,0 +1,39 @@
+# References
+
+Theory, tooling, and inspiration consulted while building the Robotic Writer.
+
+## 1. Robotics — Kinematics & Trajectory
+
+1. **Craig, J. J.** *Introduction to Robotics: Mechanics and Control* (3rd ed.), Pearson, 2005. — canonical reference for the Denavit-Hartenberg convention and the FK/IK derivations used in [equations/kinematics.md](equations/kinematics.md).
+2. **Spong, M. W., Hutchinson, S., Vidyasagar, M.** *Robot Modeling and Control*, Wiley, 2005. — planar 2R arm geometry underlying the θ₂, θ₃ closed-form solution.
+3. **Siciliano, B., Khatib, O. (eds.)** *Springer Handbook of Robotics* (2nd ed.), 2016. — trajectory planning background (cubic / quintic splines).
+4. **LaValle, S. M.** *Planning Algorithms*, Cambridge University Press, 2006. Free at http://lavalle.pl/planning/. — RRT formulation used in `src/core/rrt_planner.py`.
+
+## 2. Scorbot III Hardware (Origin)
+
+5. **Eshed Robotec, Scorbot-ER III User's Manual**, 1988. — physical parameters (link lengths, joint ranges) informing the DH table in the code.
+6. **Universidad de Concepción, Curso Control Automático I (2004)** — lab assignment that seeded this project; see project origin note in the README.
+
+## 3. Arduino / Stepper Motor Stack
+
+7. **Pololu A4988 / DRV8825 datasheets** — step/direction logic that the `ArduinoAdapter` protocol targets. See [arduino_firmware.md](arduino_firmware.md).
+8. **Arduino AccelStepper library** — acceleration profile design reference for the firmware half of the Arduino backend.
+
+## 4. Web Stack
+
+9. **Ramírez, S.** *FastAPI Documentation* — https://fastapi.tiangolo.com/. Pydantic schema patterns used for every endpoint in `src/api/main.py`.
+10. **Plotly Dash Documentation** — https://dash.plotly.com/. Source for the callback patterns and 3D scene used in `src/frontend/app.py`.
+
+## 5. Cursive / Bezier
+
+11. **de Casteljau, P.** *Outillages méthodes calcul*, 1959. — algorithmic foundation for the Bezier curves generated in `core/cursive.py`.
+
+## 6. Project-Internal
+
+- [README.md](../README.md) — project overview, KPIs, quick start.
+- [methodology.md](methodology.md) — problem statement.
+- [architecture.md](architecture.md) — system decomposition.
+- [equations/kinematics.md](equations/kinematics.md) — full FK/IK derivations.
+- [arduino_firmware.md](arduino_firmware.md) — wire protocol for the Arduino backend.
+- [development_history.md](development_history.md) — change log (re-exported from `Methodology_history.md`).
+- [user_guide.md](user_guide.md) — end-user workflow.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,123 @@
+# User Guide — Robotic Writer
+
+End-to-end walkthrough for running the Robotic Writer in simulation or against real hardware. Aimed at a first-time user who already has Python 3.12+ and Git installed.
+
+## 1. Install
+
+```bash
+git clone https://github.com/fsantibanezleal/Udec_Robotic_Writer.git
+cd Udec_Robotic_Writer
+python -m venv .venv
+# Windows:  .venv\Scripts\activate
+# Unix:     source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## 2. Start the GUI (simulation only)
+
+```bash
+python run_frontend.py
+```
+
+Open http://localhost:8055. The GUI has three tabs:
+
+| Tab | What you can do |
+|---|---|
+| **Kinematics** | Slide joint angles, read live FK; enter a target (x,y,z) and read IK; see joint limits highlighted in red if out of range. |
+| **Writer** | Type a string (≤ 50 chars), adjust block radius / angular separation / writing offset, click **Run Simulation**. |
+| **Animation** | Play / pause / seek through the trajectory recorded by the writer. |
+
+Recommended first run: **Writer tab → type `HELLO` → Run Simulation → switch to Animation**.
+
+## 3. Start the API (optional)
+
+In a separate terminal:
+
+```bash
+python run_api.py
+```
+
+Open http://localhost:8005/docs for the auto-generated Swagger UI. The most useful endpoint for scripting is `POST /api/writer/simulate`:
+
+```bash
+curl -X POST http://localhost:8005/api/writer/simulate \
+     -H "Content-Type: application/json" \
+     -d '{"text":"HELLO","block_radius_mm":280,"writing_angular_spacing_deg":4}'
+```
+
+The response contains the full joint-angle trajectory plus end-effector positions and timestamps — see [architecture.md §2](architecture.md) for the request lifecycle.
+
+## 4. Drive Real Hardware
+
+Pick one backend.
+
+### 4.1 Scorbot III (direct serial)
+
+```python
+from src.hardware import SerialAdapter
+a = SerialAdapter()
+a.connect(port="COM1", baud=9600)   # adjust to your port
+a.move_motor(1, 500)                # +500 steps on base joint
+a.disconnect()
+```
+
+### 4.2 Arduino stepper rig
+
+Flash the firmware in [arduino_firmware.md](arduino_firmware.md), then:
+
+```python
+from src.hardware import ArduinoAdapter
+a = ArduinoAdapter()
+a.connect(port="COM3", baud=115200)
+a.move_motor(1, 500)
+a.disconnect()
+```
+
+### 4.3 MATLAB Engine (legacy Scorbot scripts)
+
+```bash
+pip install matlabengine        # requires local MATLAB install
+```
+
+```python
+from src.hardware import MatlabAdapter
+a = MatlabAdapter()
+a.connect()                     # starts MATLAB session
+a.move_motor(1, 500)
+a.disconnect()
+```
+
+## 5. Common Workflows
+
+| Goal | Steps |
+|---|---|
+| **Check if a point is reachable** | Kinematics tab → type the target → if no red joint-limit warning, it's reachable |
+| **Tune block spacing** | Writer tab → increase `min_angular_separation_deg` until the 3D view shows clear gaps |
+| **Compare block vs cursive** | Writer tab → toggle writing mode → Run Simulation → compare Animation tab |
+| **Debug an IK failure** | Call `POST /api/kinematics/inverse` directly — the error message tells you which joint hit a limit |
+
+## 6. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| GUI shows "Connection refused" | API not running | Start `python run_api.py` in a second terminal |
+| Animation stutters | Old browser / low GPU | Reduce trajectory density or shorten the input text |
+| IK returns error | Target outside workspace | Reduce block radius or lift z slightly |
+| `Port in use` on 8005 / 8055 | Another instance running | Kill the process or change the port in `run_api.py` / `run_frontend.py` |
+| Real robot doesn't move | Wrong COM port / baud | Verify in Device Manager (Windows) or `ls /dev/tty*` (Unix) |
+
+## 7. Tests
+
+```bash
+pip install pytest
+pytest tests/ -v
+```
+
+Expect 83 tests to pass (see the [README metrics table](../README.md#project-metrics--status)).
+
+## 8. Where to Go Next
+
+- [methodology.md](methodology.md) — the problem the robot is solving.
+- [architecture.md](architecture.md) — how the pieces fit together.
+- [equations/kinematics.md](equations/kinematics.md) — the math.
+- [references.md](references.md) — external reading.


### PR DESCRIPTION
Closes #20.

## Summary
- Add `docs/architecture.md` — layered view, request lifecycle for `POST /api/writer/simulate`, module responsibilities, extension points, test strategy.
- Add `docs/references.md` — curated bibliography (Craig, Spong, LaValle, Scorbot ER-III manual, FastAPI / Dash, de Casteljau).
- Add `docs/user_guide.md` — install, GUI tour, API curl example, 3 hardware backends, troubleshooting table.
- Rename `docs/Methodology_history.md` -> `docs/development_history.md` (repo-wide convention) and append a v2.8 entry for this pass.
- Update README documentation table with the 3 new doc links.

## Test plan
- [x] `pytest tests/ -q` -> **83 passed**.
- [x] All new cross-references resolve (verified with `ls`).
- [x] Private-data sweep clean; deployment slug committed to `CAOS_MANAGE/deployments/robotic-writer.md`.
- [ ] Render the new docs on GitHub and confirm tables + code blocks look right.

No code changes.