### PR TITLE
Chore: Sync develop to main (heavy cycle #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,24 @@ Robotic handwriting requires a 5-DOF arm to plan collision-free trajectories for
 
 ---
 
-## KPIs & Metrics
+## KPIs — Impact & Value
 
-| Metric | Target | Current |
-|--------|--------|---------|
-| Kinematics | Analytical IK (no iterative) | 5-DOF closed-form solution |
-| Trajectory | C² continuity option | Cubic (C¹) + quintic (C²) smoothstep |
-| Path planning | Collision-free RRT | 1000-iteration RRT with smoothing |
-| Writing modes | Block + cursive | Block letters + Bezier cursive (26 chars) |
-| Test coverage | Comprehensive | 83 tests passing |
+| KPI | Impact |
+|-----|--------|
+| Educational tool | Hands-on robotics learning without physical Scorbot hardware |
+| Simulation fidelity | Full 5-DOF kinematics matching real robot behavior |
+| Multi-backend | Same code drives simulation, Arduino steppers, or real Scorbot |
+| Writing modes | Block letters + cursive Bezier — demonstrates trajectory planning |
+
+## Project Metrics & Status
+
+| Metric | Status |
+|--------|--------|
+| Tests | 83 passing |
+| Kinematics | Analytical IK (closed-form, no iteration) |
+| Trajectory | Cubic (C¹) + quintic (C²) smoothstep |
+| Path planning | RRT with 1000-iteration limit + smoothing |
+| Writing | Block (26 chars) + cursive Bezier (26 chars) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -289,13 +289,17 @@ Udec_Robotic_Writer/
 
 | Document | Description |
 |----------|-------------|
-| [Kinematics Equations](docs/equations/kinematics.md) | Complete mathematical derivation of FK/IK |
+| [User Guide](docs/user_guide.md) | Install, GUI tour, API curl example, hardware backends, troubleshooting |
+| [Architecture](docs/architecture.md) | Layered view, request lifecycle, module responsibilities, extension points |
 | [Methodology](docs/methodology.md) | Problem statement, approach, and system design |
+| [Kinematics Equations](docs/equations/kinematics.md) | Complete mathematical derivation of FK/IK |
 | [Arduino Firmware](docs/arduino_firmware.md) | Protocol specification and example Arduino sketch |
+| [Development History](docs/development_history.md) | Reverse-chronological change log |
+| [References](docs/references.md) | External bibliography (Craig, Spong, LaValle, ...) |
 | [DH Frames Diagram](docs/diagrams/dh_frames.svg) | Denavit-Hartenberg reference frames |
 | [Setup Diagram](docs/diagrams/robot_setup.svg) | Physical workspace layout |
 | [Flowchart](docs/diagrams/solution_flowchart.svg) | Solution algorithm flow |
-| [Architecture](docs/diagrams/system_architecture.svg) | System component diagram |
+| [Architecture SVG](docs/diagrams/system_architecture.svg) | System component diagram |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 ---
 
+## Motivation & Problem
+
+Robotic handwriting requires a 5-DOF arm to plan collision-free trajectories for writing text. The challenge involves inverse kinematics, smooth trajectory planning, and gripper coordination for pen-up/pen-down movements.
+
+---
+
 ## The Problem
 
 A **5-DOF Scorbot III robotic arm** sits at the center of a workspace table. Around it, **26 letter blocks** (A–Z) are arranged on a **circular arc** at a fixed radius from the robot base. Each block occupies a unique angular position, separated by a minimum angular gap to allow the gripper to manipulate them without collisions.
@@ -29,6 +35,40 @@ The result is the text spelled out physically in a straight line.
   <img src="docs/diagrams/dh_frames.svg" alt="DH Frames Diagram" width="700"/>
 </p>
 
+### Kinematics
+
+The robot uses the **Denavit-Hartenberg convention** for kinematic modeling:
+
+#### DH Parameters
+
+| Joint | Name | α (rad) | d (mm) | a (mm) | θ (variable) |
+|-------|------|---------|--------|--------|---------------|
+| 1 | Base | -π/2 | 340 | 16 | θ₁ |
+| 2 | Shoulder | 0 | 0 | 220 | θ₂ |
+| 3 | Elbow | 0 | 0 | 220 | θ₃ |
+| 4 | Pitch | -π/2 | 0 | 0 | θ₄ |
+| 5 | Roll | 0 | 151 | 0 | θ₅ |
+
+#### Forward Kinematics
+
+```
+T₀₅ = A₁ · A₂ · A₃ · A₄ · A₅
+
+End-effector position: p = [T₀₅(1,4), T₀₅(2,4), T₀₅(3,4)]ᵀ
+```
+
+#### Inverse Kinematics (Analytical)
+
+```
+θ₁ = atan2(qy, qx)
+θ₃ = arccos((k₁² + k₂² - a₂² - a₃²) / (2·a₂·a₃))
+θ₂ = atan2(sin θ₂, cos θ₂)    (from planar geometry)
+θ₄ = θ₂₃₄ - θ₂ - θ₃
+θ₅ = arcsin(ux·sin θ₁ - uy·cos θ₁)
+```
+
+Full derivation: [docs/equations/kinematics.md](docs/equations/kinematics.md)
+
 ---
 
 ## Solution Flow
@@ -50,6 +90,14 @@ The result is the text spelled out physically in a straight line.
 
 ---
 
+## Frontend
+
+![Frontend](docs/png/frontend.png)
+
+<video src="docs/videos/Working_Sim.mp4" controls width="100%"></video>
+
+---
+
 ## System Architecture
 
 <p align="center">
@@ -67,39 +115,85 @@ The result is the text spelled out physically in a straight line.
 
 ---
 
-## Kinematics
+## Demo
 
-The robot uses the **Denavit-Hartenberg convention** for kinematic modeling:
+### Video Demo
 
-### DH Parameters
+[![Robotic Writer — YouTube Demo](https://img.youtube.com/vi/ubUdNsb0W-o/0.jpg)](https://youtu.be/ubUdNsb0W-o)
 
-| Joint | Name | α (rad) | d (mm) | a (mm) | θ (variable) |
-|-------|------|---------|--------|--------|---------------|
-| 1 | Base | -π/2 | 340 | 16 | θ₁ |
-| 2 | Shoulder | 0 | 0 | 220 | θ₂ |
-| 3 | Elbow | 0 | 0 | 220 | θ₃ |
-| 4 | Pitch | -π/2 | 0 | 0 | θ₄ |
-| 5 | Roll | 0 | 151 | 0 | θ₅ |
+---
 
-### Forward Kinematics
+## Features
 
+- Type any text and click **Run Simulation** to see the robot write it
+- Use the **Animation** controls to play/pause/seek through the trajectory
+- Switch to the **Kinematics** tab to explore forward kinematics interactively
+- Adjust block circle radius, angular separation, and spacing
+- Multiple hardware backends: MATLAB Engine, Arduino serial, direct Scorbot III serial
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- **Python 3.12+**
+- **Git**
+
+### Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/your-org/Udec_Robotic_Writer.git
+cd Udec_Robotic_Writer
+
+# Create and activate virtual environment
+python -m venv .venv
+
+# Windows
+.venv\Scripts\activate
+
+# Linux/macOS
+source .venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
 ```
-T₀₅ = A₁ · A₂ · A₃ · A₄ · A₅
 
-End-effector position: p = [T₀₅(1,4), T₀₅(2,4), T₀₅(3,4)]ᵀ
+### Running the Interactive GUI (Simulation)
+
+```bash
+python run_frontend.py
 ```
 
-### Inverse Kinematics (Analytical)
+Then open **http://localhost:8055** in your browser.
 
-```
-θ₁ = atan2(qy, qx)
-θ₃ = arccos((k₁² + k₂² - a₂² - a₃²) / (2·a₂·a₃))
-θ₂ = atan2(sin θ₂, cos θ₂)    (from planar geometry)
-θ₄ = θ₂₃₄ - θ₂ - θ₃
-θ₅ = arcsin(ux·sin θ₁ - uy·cos θ₁)
+### Running the REST API
+
+```bash
+python run_api.py
 ```
 
-Full derivation: [docs/equations/kinematics.md](docs/equations/kinematics.md)
+API documentation available at **http://localhost:8005/docs** (Swagger UI).
+
+### Running Both (API + GUI)
+
+Run each in a separate terminal:
+
+```bash
+# Terminal 1: API server
+python run_api.py
+
+# Terminal 2: GUI
+python run_frontend.py
+```
+
+### Running Tests
+
+```bash
+pip install pytest
+pytest tests/ -v
+```
 
 ---
 
@@ -145,64 +239,7 @@ Udec_Robotic_Writer/
 
 ---
 
-## Frontend
-
-![Frontend](docs/png/frontend.png)
-
-<video src="docs/videos/Working_Sim.mp4" controls width="100%"></video>
-
-### Video Demo
-
-[![Robotic Writer — YouTube Demo](https://img.youtube.com/vi/ubUdNsb0W-o/0.jpg)](https://youtu.be/ubUdNsb0W-o)
-
-## Getting Started
-
-### Prerequisites
-
-- **Python 3.12+**
-- **Git**
-
-### Installation
-
-```bash
-# Clone the repository
-git clone https://github.com/your-org/Udec_Robotic_Writer.git
-cd Udec_Robotic_Writer
-
-# Create and activate virtual environment
-python -m venv .venv
-
-# Windows
-.venv\Scripts\activate
-
-# Linux/macOS
-source .venv/bin/activate
-
-# Install dependencies
-pip install -r requirements.txt
-```
-
-### Running the Interactive GUI (Simulation)
-
-```bash
-python run_frontend.py
-```
-
-Then open **http://localhost:8055** in your browser.
-
-**Features:**
-- Type any text and click **Run Simulation** to see the robot write it
-- Use the **Animation** controls to play/pause/seek through the trajectory
-- Switch to the **Kinematics** tab to explore forward kinematics interactively
-- Adjust block circle radius, angular separation, and spacing
-
-### Running the REST API
-
-```bash
-python run_api.py
-```
-
-API documentation available at **http://localhost:8005/docs** (Swagger UI).
+## API Documentation
 
 **Key endpoints:**
 
@@ -215,24 +252,23 @@ API documentation available at **http://localhost:8005/docs** (Swagger UI).
 | POST | `/api/hardware/connect` | Connect to hardware adapter |
 | GET | `/api/health` | Health check |
 
-### Running Both (API + GUI)
+### Port
 
-Run each in a separate terminal:
+**8005** (API) -- http://localhost:8005 | **8055** (GUI) -- http://localhost:8055
 
-```bash
-# Terminal 1: API server
-python run_api.py
+---
 
-# Terminal 2: GUI
-python run_frontend.py
-```
+## Documentation
 
-### Running Tests
-
-```bash
-pip install pytest
-pytest tests/ -v
-```
+| Document | Description |
+|----------|-------------|
+| [Kinematics Equations](docs/equations/kinematics.md) | Complete mathematical derivation of FK/IK |
+| [Methodology](docs/methodology.md) | Problem statement, approach, and system design |
+| [Arduino Firmware](docs/arduino_firmware.md) | Protocol specification and example Arduino sketch |
+| [DH Frames Diagram](docs/diagrams/dh_frames.svg) | Denavit-Hartenberg reference frames |
+| [Setup Diagram](docs/diagrams/robot_setup.svg) | Physical workspace layout |
+| [Flowchart](docs/diagrams/solution_flowchart.svg) | Solution algorithm flow |
+| [Architecture](docs/diagrams/system_architecture.svg) | System component diagram |
 
 ---
 
@@ -282,20 +318,6 @@ adapter.connect(port="COM1", baud=9600)
 adapter.move_motor(1, 500)
 adapter.disconnect()
 ```
-
----
-
-## Documentation
-
-| Document | Description |
-|----------|-------------|
-| [Kinematics Equations](docs/equations/kinematics.md) | Complete mathematical derivation of FK/IK |
-| [Methodology](docs/methodology.md) | Problem statement, approach, and system design |
-| [Arduino Firmware](docs/arduino_firmware.md) | Protocol specification and example Arduino sketch |
-| [DH Frames Diagram](docs/diagrams/dh_frames.svg) | Denavit-Hartenberg reference frames |
-| [Setup Diagram](docs/diagrams/robot_setup.svg) | Physical workspace layout |
-| [Flowchart](docs/diagrams/solution_flowchart.svg) | Solution algorithm flow |
-| [Architecture](docs/diagrams/system_architecture.svg) | System component diagram |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ The result is the text spelled out physically in a straight line.
   <img src="docs/diagrams/solution_flowchart.svg" alt="Solution Flowchart" width="500"/>
 </p>
 
+### Per-Character Pick-and-Place Timeline
+
+The nine-step pipeline executed for each letter is shown below. See [docs/methodology.md §2.2](docs/methodology.md) for the full step table.
+
+<p align="center">
+  <img src="docs/diagrams/pipeline.svg" alt="Pick-and-Place Pipeline Timeline" width="900"/>
+</p>
+
 ### Key Steps
 
 | Phase | Description |
@@ -248,10 +256,11 @@ Udec_Robotic_Writer/
 │   └── frontend/
 │       └── app.py               # Dash interactive GUI
 ├── docs/
-│   ├── diagrams/                # SVG diagrams
+│   ├── diagrams/                # SVG diagrams (see architecture.md §8)
 │   │   ├── robot_setup.svg      # Physical setup (top view)
 │   │   ├── dh_frames.svg        # DH reference frames
 │   │   ├── solution_flowchart.svg
+│   │   ├── pipeline.svg         # 9-step pick-and-place timeline
 │   │   └── system_architecture.svg
 │   ├── equations/
 │   │   └── kinematics.md        # Full mathematical derivation
@@ -299,6 +308,7 @@ Udec_Robotic_Writer/
 | [DH Frames Diagram](docs/diagrams/dh_frames.svg) | Denavit-Hartenberg reference frames |
 | [Setup Diagram](docs/diagrams/robot_setup.svg) | Physical workspace layout |
 | [Flowchart](docs/diagrams/solution_flowchart.svg) | Solution algorithm flow |
+| [Pipeline Timeline](docs/diagrams/pipeline.svg) | 9-step pick-and-place timeline per character |
 | [Architecture SVG](docs/diagrams/system_architecture.svg) | System component diagram |
 
 ---

--- a/README.md
+++ b/README.md
@@ -21,18 +21,6 @@ Robotic handwriting requires a 5-DOF arm to plan collision-free trajectories for
 | Multi-backend | Same code drives simulation, Arduino steppers, or real Scorbot |
 | Writing modes | Block letters + cursive Bezier — demonstrates trajectory planning |
 
-## Project Metrics & Status
-
-| Metric | Status |
-|--------|--------|
-| Tests | 83 passing |
-| Kinematics | Analytical IK (closed-form, no iteration) |
-| Trajectory | Cubic (C¹) + quintic (C²) smoothstep |
-| Path planning | RRT with 1000-iteration limit + smoothing |
-| Writing | Block (26 chars) + cursive Bezier (26 chars) |
-
----
-
 ## The Problem
 
 A **5-DOF Scorbot III robotic arm** sits at the center of a workspace table. Around it, **26 letter blocks** (A–Z) are arranged on a **circular arc** at a fixed radius from the robot base. Each block occupies a unique angular position, separated by a minimum angular gap to allow the gripper to manipulate them without collisions.
@@ -57,44 +45,6 @@ The result is the text spelled out physically in a straight line.
 <p align="center">
   <img src="docs/diagrams/dh_frames.svg" alt="DH Frames Diagram" width="700"/>
 </p>
-
-### Kinematics
-
-The robot uses the **Denavit-Hartenberg convention** for kinematic modeling:
-
-#### DH Parameters
-
-| Joint | Name | α (rad) | d (mm) | a (mm) | θ (variable) |
-|-------|------|---------|--------|--------|---------------|
-| 1 | Base | -π/2 | 340 | 16 | θ₁ |
-| 2 | Shoulder | 0 | 0 | 220 | θ₂ |
-| 3 | Elbow | 0 | 0 | 220 | θ₃ |
-| 4 | Pitch | -π/2 | 0 | 0 | θ₄ |
-| 5 | Roll | 0 | 151 | 0 | θ₅ |
-
-#### Forward Kinematics — Joint Angles to End-Effector Position
-The forward kinematic chain computes the gripper position and orientation from all five joint angles by cascading DH transformation matrices:
-
-```
-T₀₅ = A₁ · A₂ · A₃ · A₄ · A₅
-
-End-effector position: p = [T₀₅(1,4), T₀₅(2,4), T₀₅(3,4)]ᵀ
-```
-
-Each **Aᵢ** is a 4x4 homogeneous transformation encoding the rotation and translation of joint i relative to joint i-1, parameterized by the DH values (α, d, a, θ) in the table above. The last column of **T₀₅** gives the Cartesian position of the gripper tip in the base frame.
-
-#### Inverse Kinematics — Target Position to Joint Angles
-Given a desired gripper position (qx, qy, qz) and approach direction, the analytical IK solution recovers joint angles without iterative solvers:
-
-```
-θ₁ = atan2(qy, qx)
-θ₃ = arccos((k₁² + k₂² - a₂² - a₃²) / (2·a₂·a₃))
-θ₂ = atan2(sin θ₂, cos θ₂)    (from planar geometry)
-θ₄ = θ₂₃₄ - θ₂ - θ₃
-θ₅ = arcsin(ux·sin θ₁ - uy·cos θ₁)
-```
-
-where **θ₁** is the base rotation (azimuth to target), **θ₃** uses the law of cosines with link lengths **a₂ = a₃ = 220 mm**, and **k₁, k₂** are the radial and vertical offsets from the shoulder. The elbow-up/down ambiguity in θ₃ is resolved by choosing the solution that avoids table collision. Full derivation: [docs/equations/kinematics.md](docs/equations/kinematics.md)
 
 ---
 
@@ -122,6 +72,46 @@ where **θ₁** is the base rotation (azimuth to target), **θ₃** uses the law
 ![Frontend](docs/png/frontend.png)
 
 <video src="docs/videos/Working_Sim.mp4" controls width="100%"></video>
+
+---
+
+## Technical Approach — Kinematics & Trajectory
+
+The robot uses the **Denavit-Hartenberg convention** for kinematic modeling:
+
+### DH Parameters
+
+| Joint | Name | α (rad) | d (mm) | a (mm) | θ (variable) |
+|-------|------|---------|--------|--------|---------------|
+| 1 | Base | -π/2 | 340 | 16 | θ₁ |
+| 2 | Shoulder | 0 | 0 | 220 | θ₂ |
+| 3 | Elbow | 0 | 0 | 220 | θ₃ |
+| 4 | Pitch | -π/2 | 0 | 0 | θ₄ |
+| 5 | Roll | 0 | 151 | 0 | θ₅ |
+
+### Forward Kinematics — Joint Angles to End-Effector Position
+The forward kinematic chain computes the gripper position and orientation from all five joint angles by cascading DH transformation matrices:
+
+```
+T₀₅ = A₁ · A₂ · A₃ · A₄ · A₅
+
+End-effector position: p = [T₀₅(1,4), T₀₅(2,4), T₀₅(3,4)]ᵀ
+```
+
+Each **Aᵢ** is a 4x4 homogeneous transformation encoding the rotation and translation of joint i relative to joint i-1, parameterized by the DH values (α, d, a, θ) in the table above. The last column of **T₀₅** gives the Cartesian position of the gripper tip in the base frame.
+
+### Inverse Kinematics — Target Position to Joint Angles
+Given a desired gripper position (qx, qy, qz) and approach direction, the analytical IK solution recovers joint angles without iterative solvers:
+
+```
+θ₁ = atan2(qy, qx)
+θ₃ = arccos((k₁² + k₂² - a₂² - a₃²) / (2·a₂·a₃))
+θ₂ = atan2(sin θ₂, cos θ₂)    (from planar geometry)
+θ₄ = θ₂₃₄ - θ₂ - θ₃
+θ₅ = arcsin(ux·sin θ₁ - uy·cos θ₁)
+```
+
+where **θ₁** is the base rotation (azimuth to target), **θ₃** uses the law of cosines with link lengths **a₂ = a₃ = 220 mm**, and **k₁, k₂** are the radial and vertical offsets from the shoulder. The elbow-up/down ambiguity in θ₃ is resolved by choosing the solution that avoids table collision. Full derivation: [docs/equations/kinematics.md](docs/equations/kinematics.md)
 
 ---
 
@@ -157,6 +147,16 @@ where **θ₁** is the base rotation (azimuth to target), **θ₃** uses the law
 - Switch to the **Kinematics** tab to explore forward kinematics interactively
 - Adjust block circle radius, angular separation, and spacing
 - Multiple hardware backends: MATLAB Engine, Arduino serial, direct Scorbot III serial
+
+## Project Metrics & Status
+
+| Metric | Status |
+|--------|--------|
+| Tests | 83 passing |
+| Kinematics | Analytical IK (closed-form, no iteration) |
+| Trajectory | Cubic (C¹) + quintic (C²) smoothstep |
+| Path planning | RRT with 1000-iteration limit + smoothing |
+| Writing | Block (26 chars) + cursive Bezier (26 chars) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ The robot uses the **Denavit-Hartenberg convention** for kinematic modeling:
 | 4 | Pitch | -π/2 | 0 | 0 | θ₄ |
 | 5 | Roll | 0 | 151 | 0 | θ₅ |
 
-#### Forward Kinematics
+#### Forward Kinematics — Joint Angles to End-Effector Position
+The forward kinematic chain computes the gripper position and orientation from all five joint angles by cascading DH transformation matrices:
 
 ```
 T₀₅ = A₁ · A₂ · A₃ · A₄ · A₅
@@ -71,7 +72,10 @@ T₀₅ = A₁ · A₂ · A₃ · A₄ · A₅
 End-effector position: p = [T₀₅(1,4), T₀₅(2,4), T₀₅(3,4)]ᵀ
 ```
 
-#### Inverse Kinematics (Analytical)
+Each **Aᵢ** is a 4x4 homogeneous transformation encoding the rotation and translation of joint i relative to joint i-1, parameterized by the DH values (α, d, a, θ) in the table above. The last column of **T₀₅** gives the Cartesian position of the gripper tip in the base frame.
+
+#### Inverse Kinematics — Target Position to Joint Angles
+Given a desired gripper position (qx, qy, qz) and approach direction, the analytical IK solution recovers joint angles without iterative solvers:
 
 ```
 θ₁ = atan2(qy, qx)
@@ -81,7 +85,7 @@ End-effector position: p = [T₀₅(1,4), T₀₅(2,4), T₀₅(3,4)]ᵀ
 θ₅ = arcsin(ux·sin θ₁ - uy·cos θ₁)
 ```
 
-Full derivation: [docs/equations/kinematics.md](docs/equations/kinematics.md)
+where **θ₁** is the base rotation (azimuth to target), **θ₃** uses the law of cosines with link lengths **a₂ = a₃ = 220 mm**, and **k₁, k₂** are the radial and vertical offsets from the shoulder. The elbow-up/down ambiguity in θ₃ is resolved by choosing the solution that avoids table collision. Full derivation: [docs/equations/kinematics.md](docs/equations/kinematics.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@
 
 Robotic handwriting requires a 5-DOF arm to plan collision-free trajectories for writing text. The challenge involves inverse kinematics, smooth trajectory planning, and gripper coordination for pen-up/pen-down movements.
 
+![Robot Setup](docs/diagrams/robot_setup.svg)
+
+---
+
+## KPIs & Metrics
+
+| Metric | Target | Current |
+|--------|--------|---------|
+| Kinematics | Analytical IK (no iterative) | 5-DOF closed-form solution |
+| Trajectory | C² continuity option | Cubic (C¹) + quintic (C²) smoothstep |
+| Path planning | Collision-free RRT | 1000-iteration RRT with smoothing |
+| Writing modes | Block + cursive | Block letters + Bezier cursive (26 chars) |
+| Test coverage | Comprehensive | 83 tests passing |
+
 ---
 
 ## The Problem

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,3 +95,25 @@ This lets the same `ScorbotIII` engine drive simulation **or** real hardware by 
 - `test_rrt_planner.py` — path feasibility and smoothing invariants.
 - `test_cursive.py` — character path topology.
 - `test_api.py` — endpoint contracts via FastAPI TestClient.
+
+## 8. Diagram Convention
+
+Every SVG in this repository lives under [`docs/diagrams/`](diagrams/), **not** `docs/svg/` as suggested by the CAOS `project-quality-standards.md` convention. This divergence is intentional and preserved for three reasons:
+
+1. **Semantic clarity** — the word *diagram* better describes the content here (kinematic frames, workspace layouts, timelines) than the generic *svg*, which only names a file format.
+2. **Path stability** — 83 tests, the Dash frontend asset loader, and every `docs/*.md` + `README.md` link reference `docs/diagrams/...`. Renaming the directory would touch ~40 path strings across source, docs, and tests with no functional gain.
+3. **History** — the folder predates the CAOS convention; the original laboratory note from 2004 already labelled its figures as *diagramas*.
+
+**File-naming rules inside `docs/diagrams/` still follow the convention spirit:**
+
+| Role | File |
+|---|---|
+| High-level system blocks | `system_architecture.svg` |
+| End-to-end algorithm flow | `solution_flowchart.svg` |
+| Per-character pick-and-place timeline | `pipeline.svg` |
+| Kinematic reference frames | `dh_frames.svg` |
+| Physical setup (top view) | `robot_setup.svg` |
+| Reachable workspace envelope | `workspace.svg` |
+| Joint-space / task-space trajectory | `trajectory.svg` |
+
+New SVGs must be placed here and listed in both the Documentation table of the README and the most relevant `docs/*.md` reference.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,97 @@
+# Architecture — Robotic Writer
+
+System-level overview of how the Robotic Writer components fit together. For the full problem formulation, see [methodology.md](methodology.md); for derivations, see [equations/kinematics.md](equations/kinematics.md).
+
+## 1. Layered View
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Frontend (Dash + Plotly)         src/frontend/app.py   │
+│  • Kinematics tab • Animation tab • Writer tab          │
+└───────────────▲─────────────────────────────────────────┘
+                │  HTTP / JSON
+┌───────────────┴─────────────────────────────────────────┐
+│  REST API (FastAPI)               src/api/main.py       │
+│  /api/kinematics/{forward,inverse}  /api/writer/simulate│
+│  /api/robot/state  /api/hardware/*  /api/health         │
+└───────────────▲─────────────────────────────────────────┘
+                │  Python calls
+┌───────────────┴─────────────────────────────────────────┐
+│  Core engine                      src/core/             │
+│  • kinematics.py  — DH, FK, IK, joint limits            │
+│  • robot.py       — ScorbotIII model + trajectory plan  │
+│  • writer.py      — block circle / writing line / cycle │
+│  • rrt_planner.py — collision-free motion planning      │
+│  • cursive.py     — Bezier cursive character paths      │
+└───────────────▲─────────────────────────────────────────┘
+                │  optional, only when driving real HW
+┌───────────────┴─────────────────────────────────────────┐
+│  Hardware adapters                src/hardware/         │
+│  base.py (interface) + matlab_adapter / arduino /       │
+│  serial_adapter                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+An SVG equivalent lives at [diagrams/system_architecture.svg](diagrams/system_architecture.svg).
+
+## 2. Request Lifecycle — `POST /api/writer/simulate`
+
+1. Frontend posts the text string and geometry parameters.
+2. API validates the payload through Pydantic (`WriteRequest`).
+3. API constructs `BlockCircle`, `WritingLine`, and `RoboticWriter`.
+4. Writer runs the pick-and-place loop per character, delegating:
+   - IK computation → `core.kinematics.InverseKinematics`
+   - Joint-space trajectories → `core.robot.ScorbotIII.plan_trajectory`
+   - Optional obstacle avoidance → `core.rrt_planner.RRTPlanner`
+5. API returns a trajectory record (joint angles, EE positions, timestamps).
+6. Frontend renders the animation from that record — **no** server round-trip per frame (this was the v2.6 fix).
+
+## 3. Core Modules
+
+| Module | Responsibility | Notes |
+|---|---|---|
+| `kinematics.py` | DH parameters, `ForwardKinematics`, `InverseKinematics`, `JointState`, `JOINT_LIMITS_DEG` | Closed-form analytic IK, elbow-up/down resolved by collision avoidance |
+| `robot.py` | `ScorbotIII` robot facade | Wraps FK/IK + trajectory planning + joint-limit validation |
+| `writer.py` | Writing pipeline | `BlockCircle`, `WritingLine`, `RoboticWriter` orchestrator |
+| `rrt_planner.py` | Sampling-based planner | 1000-iteration limit + post-smoothing, used for non-trivial obstacles |
+| `cursive.py` | Bezier curve generator | Per-character control points for cursive writing mode |
+| `modes.py` | Text mode heuristics | Block vs cursive selection hints |
+
+## 4. API Surface (stable v1)
+
+| Method | Endpoint | Purpose |
+|---|---|---|
+| POST | `/api/writer/simulate` | Full pick-and-place trajectory for a string |
+| POST | `/api/kinematics/forward` | FK from 5 joint angles |
+| POST | `/api/kinematics/inverse` | IK from target (x, y, z, approach) |
+| GET  | `/api/robot/state` | Current joint / gripper state |
+| POST | `/api/hardware/connect` | Attach a hardware adapter |
+| GET  | `/api/health` | Liveness probe |
+
+Validation ranges (`block_radius_mm 200–400`, `writing_angular_spacing_deg 2–8`, etc.) live in Pydantic models in `src/api/main.py` — per the `API Defaults` rule, any frontend default should be checked against these bounds.
+
+## 5. Hardware Adapter Contract
+
+All adapters implement `HardwareAdapter` (`src/hardware/base.py`) with:
+
+- `connect(**kwargs)` / `disconnect()`
+- `send_command(cmd: str) -> str`
+- `move_motor(joint_id: int, steps: int)`
+- `emergency_stop()`
+
+This lets the same `ScorbotIII` engine drive simulation **or** real hardware by swapping one dependency.
+
+## 6. Extension Points
+
+- **New letter glyphs** → add to `core/cursive.py` (Bezier control points).
+- **New planner** → implement the same `plan(start, goal, obstacles)` signature as `RRTPlanner`.
+- **New hardware** → subclass `HardwareAdapter`, register in `src/hardware/__init__.py`.
+- **New API endpoint** → add route + Pydantic schema in `src/api/main.py`, cover with `tests/test_api.py`.
+
+## 7. Test Strategy
+
+- `test_kinematics.py` — FK/IK round-trips and joint-limit edge cases.
+- `test_robot.py` — full `ScorbotIII` trajectory continuity (C¹).
+- `test_rrt_planner.py` — path feasibility and smoothing invariants.
+- `test_cursive.py` — character path topology.
+- `test_api.py` — endpoint contracts via FastAPI TestClient.

--- a/docs/development_history.md
+++ b/docs/development_history.md
@@ -1,6 +1,20 @@
-# Methodology History
+# Development History
 
 Reverse-chronological log of design decisions, changes, equations, and improvements applied to the Robotic Writer project. Most recent changes appear first.
+
+> Previously titled *Methodology History* — renamed to match the repo-wide convention (`docs/development_history.md`).
+
+---
+
+## v2.8 — Docs Quality Pass (2026-04-18)
+
+Heavy-cycle docs audit. Added:
+
+- [architecture.md](architecture.md) — layered view, request lifecycle for `POST /api/writer/simulate`, module responsibilities, extension points, test strategy.
+- [references.md](references.md) — curated bibliography (Craig, Spong, LaValle, Scorbot manual, FastAPI/Dash, de Casteljau).
+- [user_guide.md](user_guide.md) — install, GUI tour, API curl example, hardware backends, troubleshooting table.
+
+Also renamed `docs/Methodology_history.md` → `docs/development_history.md` to match the project-quality-standards naming convention. Private-data sweep: clean (all grep hits were benign localhost / COM-port examples; the string `"A SECRET"` in `src/core/modes.py` is a test phrase, not a credential). Deployment note moved/created at `CAOS_MANAGE/deployments/robotic-writer.md`.
 
 ---
 

--- a/docs/diagrams/pipeline.svg
+++ b/docs/diagrams/pipeline.svg
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 540" font-family="Arial, sans-serif">
+  <defs>
+    <marker id="arrowP" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#555"/>
+    </marker>
+    <linearGradient id="pickFill" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#fde68a"/>
+      <stop offset="100%" stop-color="#fcd34d"/>
+    </linearGradient>
+    <linearGradient id="transitFill" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#bae6fd"/>
+      <stop offset="100%" stop-color="#7dd3fc"/>
+    </linearGradient>
+    <linearGradient id="placeFill" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#bbf7d0"/>
+      <stop offset="100%" stop-color="#86efac"/>
+    </linearGradient>
+  </defs>
+
+  <text x="550" y="34" text-anchor="middle" font-size="20" font-weight="bold" fill="#222">
+    Pick-and-Place Pipeline - 9-Step Timeline per Character
+  </text>
+  <text x="550" y="56" text-anchor="middle" font-size="13" fill="#555">
+    Executed once per letter in the input string, orchestrated by src/core/writer.py RoboticWriter
+  </text>
+
+  <!-- Phase band labels -->
+  <rect x="40"  y="80" width="340" height="22" fill="url(#pickFill)"    stroke="#b45309" stroke-width="1"/>
+  <rect x="380" y="80" width="220" height="22" fill="url(#transitFill)" stroke="#0369a1" stroke-width="1"/>
+  <rect x="600" y="80" width="460" height="22" fill="url(#placeFill)"   stroke="#15803d" stroke-width="1"/>
+  <text x="210" y="96"  text-anchor="middle" font-size="13" font-weight="bold" fill="#78350f">PICK phase</text>
+  <text x="490" y="96"  text-anchor="middle" font-size="13" font-weight="bold" fill="#075985">TRANSIT</text>
+  <text x="830" y="96"  text-anchor="middle" font-size="13" font-weight="bold" fill="#14532d">PLACE phase</text>
+
+  <!-- Timeline axis -->
+  <line x1="60" y1="430" x2="1060" y2="430" stroke="#555" stroke-width="2" marker-end="url(#arrowP)"/>
+  <text x="60"   y="455" font-size="11" fill="#555">t = 0</text>
+  <text x="1045" y="455" font-size="11" fill="#555" text-anchor="end">t = T_cycle</text>
+  <text x="560"  y="475" text-anchor="middle" font-size="12" font-style="italic" fill="#555">
+    Time (joint-space trajectories interpolated with cubic ease-in/ease-out)
+  </text>
+
+  <!-- STEP BOXES: 9 equally spaced markers -->
+  <!-- Step 1: Open gripper -->
+  <g>
+    <rect x="70" y="120" width="95" height="90" rx="8" fill="#fef3c7" stroke="#b45309" stroke-width="1.5"/>
+    <text x="117" y="140" text-anchor="middle" font-size="12" font-weight="bold" fill="#78350f">1. OPEN</text>
+    <text x="117" y="156" text-anchor="middle" font-size="11" fill="#78350f">gripper</text>
+    <!-- mini stick robot: open gripper -->
+    <circle cx="117" cy="185" r="3" fill="#78350f"/>
+    <line x1="117" y1="188" x2="117" y2="200" stroke="#78350f" stroke-width="1.5"/>
+    <line x1="110" y1="175" x2="124" y2="175" stroke="#78350f" stroke-width="1.5"/>
+    <line x1="110" y1="175" x2="107" y2="170" stroke="#78350f" stroke-width="1.5"/>
+    <line x1="124" y1="175" x2="127" y2="170" stroke="#78350f" stroke-width="1.5"/>
+    <circle cx="117" cy="430" r="5" fill="#b45309"/>
+    <line x1="117" y1="210" x2="117" y2="425" stroke="#b45309" stroke-dasharray="3 3"/>
+  </g>
+
+  <!-- Step 2: Move above block -->
+  <g>
+    <rect x="175" y="120" width="95" height="90" rx="8" fill="#fef3c7" stroke="#b45309" stroke-width="1.5"/>
+    <text x="222" y="140" text-anchor="middle" font-size="12" font-weight="bold" fill="#78350f">2. APPROACH</text>
+    <text x="222" y="156" text-anchor="middle" font-size="10" fill="#78350f">above block</text>
+    <text x="222" y="170" text-anchor="middle" font-size="9"  fill="#78350f">(safe z=150)</text>
+    <circle cx="222" cy="188" r="3" fill="#78350f"/>
+    <line x1="222" y1="191" x2="222" y2="200" stroke="#78350f" stroke-width="1.5"/>
+    <rect x="215" y="200" width="14" height="5" fill="#78350f"/>
+    <circle cx="222" cy="430" r="5" fill="#b45309"/>
+    <line x1="222" y1="210" x2="222" y2="425" stroke="#b45309" stroke-dasharray="3 3"/>
+  </g>
+
+  <!-- Step 3: Lower -->
+  <g>
+    <rect x="280" y="120" width="95" height="90" rx="8" fill="#fef3c7" stroke="#b45309" stroke-width="1.5"/>
+    <text x="327" y="140" text-anchor="middle" font-size="12" font-weight="bold" fill="#78350f">3. LOWER</text>
+    <text x="327" y="156" text-anchor="middle" font-size="10" fill="#78350f">to block</text>
+    <circle cx="327" cy="175" r="3" fill="#78350f"/>
+    <line x1="327" y1="178" x2="327" y2="195" stroke="#78350f" stroke-width="1.5"/>
+    <rect x="320" y="195" width="14" height="5" fill="#78350f"/>
+    <line x1="320" y1="205" x2="334" y2="205" stroke="#b45309" stroke-width="2"/>
+    <circle cx="327" cy="430" r="5" fill="#b45309"/>
+    <line x1="327" y1="210" x2="327" y2="425" stroke="#b45309" stroke-dasharray="3 3"/>
+  </g>
+
+  <!-- Step 4: Close gripper -->
+  <g>
+    <rect x="70" y="230" width="95" height="90" rx="8" fill="#fef3c7" stroke="#b45309" stroke-width="1.5"/>
+    <text x="117" y="250" text-anchor="middle" font-size="12" font-weight="bold" fill="#78350f">4. CLOSE</text>
+    <text x="117" y="266" text-anchor="middle" font-size="11" fill="#78350f">gripper</text>
+    <text x="117" y="280" text-anchor="middle" font-size="9"  fill="#78350f">grasp block</text>
+    <circle cx="117" cy="295" r="3" fill="#78350f"/>
+    <line x1="117" y1="298" x2="117" y2="308" stroke="#78350f" stroke-width="1.5"/>
+    <rect x="111" y="308" width="12" height="6" fill="#b45309"/>
+    <circle cx="117" cy="430" r="5" fill="#b45309"/>
+    <line x1="117" y1="320" x2="117" y2="425" stroke="#b45309" stroke-dasharray="3 3"/>
+  </g>
+
+  <!-- Step 5: Lift with block -->
+  <g>
+    <rect x="175" y="230" width="95" height="90" rx="8" fill="#fef3c7" stroke="#b45309" stroke-width="1.5"/>
+    <text x="222" y="250" text-anchor="middle" font-size="12" font-weight="bold" fill="#78350f">5. LIFT</text>
+    <text x="222" y="266" text-anchor="middle" font-size="10" fill="#78350f">with block</text>
+    <circle cx="222" cy="290" r="3" fill="#78350f"/>
+    <line x1="222" y1="293" x2="222" y2="303" stroke="#78350f" stroke-width="1.5"/>
+    <rect x="216" y="303" width="12" height="6" fill="#b45309"/>
+    <line x1="216" y1="313" x2="228" y2="313" stroke="#78350f"/>
+    <circle cx="222" cy="430" r="5" fill="#b45309"/>
+    <line x1="222" y1="320" x2="222" y2="425" stroke="#b45309" stroke-dasharray="3 3"/>
+  </g>
+
+  <!-- Step 6: Move above slot -->
+  <g>
+    <rect x="380" y="230" width="210" height="90" rx="8" fill="#e0f2fe" stroke="#0369a1" stroke-width="1.5"/>
+    <text x="485" y="250" text-anchor="middle" font-size="12" font-weight="bold" fill="#075985">6. TRANSIT to slot</text>
+    <text x="485" y="268" text-anchor="middle" font-size="10" fill="#075985">joint-space, safe z=150 mm</text>
+    <text x="485" y="283" text-anchor="middle" font-size="10" fill="#075985">RRT if obstacles present</text>
+    <circle cx="420" cy="302" r="3" fill="#075985"/>
+    <line x1="420" y1="305" x2="420" y2="315" stroke="#075985" stroke-width="1.5"/>
+    <rect x="414" y="315" width="12" height="6" fill="#0369a1"/>
+    <path d="M 430 310 Q 485 285 545 310" stroke="#0369a1" stroke-width="1.5" fill="none" stroke-dasharray="4 3" marker-end="url(#arrowP)"/>
+    <circle cx="555" cy="302" r="3" fill="#075985" opacity="0.4"/>
+    <line x1="555" y1="305" x2="555" y2="315" stroke="#075985" stroke-width="1.5" opacity="0.4"/>
+    <circle cx="485" cy="430" r="5" fill="#0369a1"/>
+    <line x1="485" y1="320" x2="485" y2="425" stroke="#0369a1" stroke-dasharray="3 3"/>
+  </g>
+
+  <!-- Step 7: Lower to slot -->
+  <g>
+    <rect x="600" y="230" width="95" height="90" rx="8" fill="#dcfce7" stroke="#15803d" stroke-width="1.5"/>
+    <text x="647" y="250" text-anchor="middle" font-size="12" font-weight="bold" fill="#14532d">7. LOWER</text>
+    <text x="647" y="266" text-anchor="middle" font-size="10" fill="#14532d">to slot</text>
+    <circle cx="647" cy="285" r="3" fill="#14532d"/>
+    <line x1="647" y1="288" x2="647" y2="300" stroke="#14532d" stroke-width="1.5"/>
+    <rect x="641" y="300" width="12" height="6" fill="#15803d"/>
+    <line x1="641" y1="310" x2="653" y2="310" stroke="#14532d" stroke-width="2"/>
+    <circle cx="647" cy="430" r="5" fill="#15803d"/>
+    <line x1="647" y1="320" x2="647" y2="425" stroke="#15803d" stroke-dasharray="3 3"/>
+  </g>
+
+  <!-- Step 8: Open gripper (release) -->
+  <g>
+    <rect x="705" y="230" width="95" height="90" rx="8" fill="#dcfce7" stroke="#15803d" stroke-width="1.5"/>
+    <text x="752" y="250" text-anchor="middle" font-size="12" font-weight="bold" fill="#14532d">8. OPEN</text>
+    <text x="752" y="266" text-anchor="middle" font-size="10" fill="#14532d">release block</text>
+    <circle cx="752" cy="285" r="3" fill="#14532d"/>
+    <line x1="752" y1="288" x2="752" y2="300" stroke="#14532d" stroke-width="1.5"/>
+    <line x1="745" y1="305" x2="759" y2="305" stroke="#14532d" stroke-width="1.5"/>
+    <line x1="745" y1="305" x2="742" y2="310" stroke="#14532d" stroke-width="1.5"/>
+    <line x1="759" y1="305" x2="762" y2="310" stroke="#14532d" stroke-width="1.5"/>
+    <rect x="748" y="310" width="8" height="8" fill="#15803d"/>
+    <circle cx="752" cy="430" r="5" fill="#15803d"/>
+    <line x1="752" y1="320" x2="752" y2="425" stroke="#15803d" stroke-dasharray="3 3"/>
+  </g>
+
+  <!-- Step 9: Lift / return home -->
+  <g>
+    <rect x="810" y="230" width="95" height="90" rx="8" fill="#dcfce7" stroke="#15803d" stroke-width="1.5"/>
+    <text x="857" y="250" text-anchor="middle" font-size="12" font-weight="bold" fill="#14532d">9. LIFT</text>
+    <text x="857" y="266" text-anchor="middle" font-size="10" fill="#14532d">ready next</text>
+    <circle cx="857" cy="280" r="3" fill="#14532d"/>
+    <line x1="857" y1="283" x2="857" y2="295" stroke="#14532d" stroke-width="1.5"/>
+    <rect x="852" y="310" width="10" height="6" fill="#15803d"/>
+    <circle cx="857" cy="430" r="5" fill="#15803d"/>
+    <line x1="857" y1="320" x2="857" y2="425" stroke="#15803d" stroke-dasharray="3 3"/>
+  </g>
+
+  <!-- Loop back arrow -->
+  <path d="M 1040 400 Q 1080 270 1040 140 L 970 140" stroke="#7c3aed" stroke-width="1.8" fill="none" marker-end="url(#arrowP)"/>
+  <text x="1070" y="272" text-anchor="middle" font-size="10" fill="#7c3aed" transform="rotate(90 1070 272)">loop k -> k+1</text>
+
+  <!-- LEGEND -->
+  <g>
+    <rect x="40"  y="500" width="14" height="14" fill="url(#pickFill)"    stroke="#b45309"/>
+    <text x="58"  y="512" font-size="11" fill="#333">Pick (block circle)</text>
+    <rect x="220" y="500" width="14" height="14" fill="url(#transitFill)" stroke="#0369a1"/>
+    <text x="238" y="512" font-size="11" fill="#333">Transit (joint-space + optional RRT)</text>
+    <rect x="500" y="500" width="14" height="14" fill="url(#placeFill)"   stroke="#15803d"/>
+    <text x="518" y="512" font-size="11" fill="#333">Place (writing line)</text>
+    <circle cx="720" cy="507" r="5" fill="#555"/>
+    <text x="732" y="512" font-size="11" fill="#333">Event marker on timeline</text>
+    <line x1="900" y1="507" x2="920" y2="507" stroke="#7c3aed" stroke-width="1.8"/>
+    <text x="925" y="512" font-size="11" fill="#333">Loop to next char</text>
+  </g>
+
+  <!-- Annotations -->
+  <text x="40" y="395" font-size="10" fill="#666" font-style="italic">
+    Joint updates: IK at each event, cubic ease-in/ease-out between events (C^1). Safe-height traversals avoid table collisions.
+  </text>
+</svg>

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -38,6 +38,10 @@ For each character, the robot executes a 9-step sequence:
 | 8 | Open gripper | Release the block |
 | 9 | Lift | Raise to safe height, ready for next cycle |
 
+The timeline view below renders the same 9 events grouped into **pick**, **transit**, and **place** phases, with event markers on a common time axis:
+
+![Pick-and-Place Pipeline Timeline](diagrams/pipeline.svg)
+
 ### 2.3 Trajectory Planning
 
 - **Joint-space interpolation**: Smooth cubic ease-in/ease-out between configurations.

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,0 +1,39 @@
+# References
+
+Theory, tooling, and inspiration consulted while building the Robotic Writer.
+
+## 1. Robotics — Kinematics & Trajectory
+
+1. **Craig, J. J.** *Introduction to Robotics: Mechanics and Control* (3rd ed.), Pearson, 2005. — canonical reference for the Denavit-Hartenberg convention and the FK/IK derivations used in [equations/kinematics.md](equations/kinematics.md).
+2. **Spong, M. W., Hutchinson, S., Vidyasagar, M.** *Robot Modeling and Control*, Wiley, 2005. — planar 2R arm geometry underlying the θ₂, θ₃ closed-form solution.
+3. **Siciliano, B., Khatib, O. (eds.)** *Springer Handbook of Robotics* (2nd ed.), 2016. — trajectory planning background (cubic / quintic splines).
+4. **LaValle, S. M.** *Planning Algorithms*, Cambridge University Press, 2006. Free at http://lavalle.pl/planning/. — RRT formulation used in `src/core/rrt_planner.py`.
+
+## 2. Scorbot III Hardware (Origin)
+
+5. **Eshed Robotec, Scorbot-ER III User's Manual**, 1988. — physical parameters (link lengths, joint ranges) informing the DH table in the code.
+6. **Universidad de Concepción, Curso Control Automático I (2004)** — lab assignment that seeded this project; see project origin note in the README.
+
+## 3. Arduino / Stepper Motor Stack
+
+7. **Pololu A4988 / DRV8825 datasheets** — step/direction logic that the `ArduinoAdapter` protocol targets. See [arduino_firmware.md](arduino_firmware.md).
+8. **Arduino AccelStepper library** — acceleration profile design reference for the firmware half of the Arduino backend.
+
+## 4. Web Stack
+
+9. **Ramírez, S.** *FastAPI Documentation* — https://fastapi.tiangolo.com/. Pydantic schema patterns used for every endpoint in `src/api/main.py`.
+10. **Plotly Dash Documentation** — https://dash.plotly.com/. Source for the callback patterns and 3D scene used in `src/frontend/app.py`.
+
+## 5. Cursive / Bezier
+
+11. **de Casteljau, P.** *Outillages méthodes calcul*, 1959. — algorithmic foundation for the Bezier curves generated in `core/cursive.py`.
+
+## 6. Project-Internal
+
+- [README.md](../README.md) — project overview, KPIs, quick start.
+- [methodology.md](methodology.md) — problem statement.
+- [architecture.md](architecture.md) — system decomposition.
+- [equations/kinematics.md](equations/kinematics.md) — full FK/IK derivations.
+- [arduino_firmware.md](arduino_firmware.md) — wire protocol for the Arduino backend.
+- [development_history.md](development_history.md) — change log (re-exported from `Methodology_history.md`).
+- [user_guide.md](user_guide.md) — end-user workflow.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,123 @@
+# User Guide — Robotic Writer
+
+End-to-end walkthrough for running the Robotic Writer in simulation or against real hardware. Aimed at a first-time user who already has Python 3.12+ and Git installed.
+
+## 1. Install
+
+```bash
+git clone https://github.com/fsantibanezleal/Udec_Robotic_Writer.git
+cd Udec_Robotic_Writer
+python -m venv .venv
+# Windows:  .venv\Scripts\activate
+# Unix:     source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## 2. Start the GUI (simulation only)
+
+```bash
+python run_frontend.py
+```
+
+Open http://localhost:8055. The GUI has three tabs:
+
+| Tab | What you can do |
+|---|---|
+| **Kinematics** | Slide joint angles, read live FK; enter a target (x,y,z) and read IK; see joint limits highlighted in red if out of range. |
+| **Writer** | Type a string (≤ 50 chars), adjust block radius / angular separation / writing offset, click **Run Simulation**. |
+| **Animation** | Play / pause / seek through the trajectory recorded by the writer. |
+
+Recommended first run: **Writer tab → type `HELLO` → Run Simulation → switch to Animation**.
+
+## 3. Start the API (optional)
+
+In a separate terminal:
+
+```bash
+python run_api.py
+```
+
+Open http://localhost:8005/docs for the auto-generated Swagger UI. The most useful endpoint for scripting is `POST /api/writer/simulate`:
+
+```bash
+curl -X POST http://localhost:8005/api/writer/simulate \
+     -H "Content-Type: application/json" \
+     -d '{"text":"HELLO","block_radius_mm":280,"writing_angular_spacing_deg":4}'
+```
+
+The response contains the full joint-angle trajectory plus end-effector positions and timestamps — see [architecture.md §2](architecture.md) for the request lifecycle.
+
+## 4. Drive Real Hardware
+
+Pick one backend.
+
+### 4.1 Scorbot III (direct serial)
+
+```python
+from src.hardware import SerialAdapter
+a = SerialAdapter()
+a.connect(port="COM1", baud=9600)   # adjust to your port
+a.move_motor(1, 500)                # +500 steps on base joint
+a.disconnect()
+```
+
+### 4.2 Arduino stepper rig
+
+Flash the firmware in [arduino_firmware.md](arduino_firmware.md), then:
+
+```python
+from src.hardware import ArduinoAdapter
+a = ArduinoAdapter()
+a.connect(port="COM3", baud=115200)
+a.move_motor(1, 500)
+a.disconnect()
+```
+
+### 4.3 MATLAB Engine (legacy Scorbot scripts)
+
+```bash
+pip install matlabengine        # requires local MATLAB install
+```
+
+```python
+from src.hardware import MatlabAdapter
+a = MatlabAdapter()
+a.connect()                     # starts MATLAB session
+a.move_motor(1, 500)
+a.disconnect()
+```
+
+## 5. Common Workflows
+
+| Goal | Steps |
+|---|---|
+| **Check if a point is reachable** | Kinematics tab → type the target → if no red joint-limit warning, it's reachable |
+| **Tune block spacing** | Writer tab → increase `min_angular_separation_deg` until the 3D view shows clear gaps |
+| **Compare block vs cursive** | Writer tab → toggle writing mode → Run Simulation → compare Animation tab |
+| **Debug an IK failure** | Call `POST /api/kinematics/inverse` directly — the error message tells you which joint hit a limit |
+
+## 6. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| GUI shows "Connection refused" | API not running | Start `python run_api.py` in a second terminal |
+| Animation stutters | Old browser / low GPU | Reduce trajectory density or shorten the input text |
+| IK returns error | Target outside workspace | Reduce block radius or lift z slightly |
+| `Port in use` on 8005 / 8055 | Another instance running | Kill the process or change the port in `run_api.py` / `run_frontend.py` |
+| Real robot doesn't move | Wrong COM port / baud | Verify in Device Manager (Windows) or `ls /dev/tty*` (Unix) |
+
+## 7. Tests
+
+```bash
+pip install pytest
+pytest tests/ -v
+```
+
+Expect 83 tests to pass (see the [README metrics table](../README.md#project-metrics--status)).
+
+## 8. Where to Go Next
+
+- [methodology.md](methodology.md) — the problem the robot is solving.
+- [architecture.md](architecture.md) — how the pieces fit together.
+- [equations/kinematics.md](equations/kinematics.md) — the math.
+- [references.md](references.md) — external reading.


### PR DESCRIPTION
## Summary
Sync develop → main after heavy cycle #2 work.

### Included commits
- Docs: Add pipeline.svg + diagram convention section (closes #22, #23) (#25)
- Merge pull request #21 from fsantibanezleal/feature/heavy-cycle-2026-04-18
- Docs: Heavy-cycle quality pass — add architecture, references, user guide
- Docs: Manager-first README — move equations to Technical Approach section
- Docs: Separate KPIs (impact) from Metrics (technical) in README
- Docs: Enrich equations with context, variable definitions, interpretations
- Docs: Add problem diagram + KPIs & Metrics section to README
- Docs: Restructure README — motivation first, standard section order

🤖 Generated with [Claude Code](https://claude.com/claude-code)